### PR TITLE
Add the trace keyword expression

### DIFF
--- a/src/chunk.rs
+++ b/src/chunk.rs
@@ -12,7 +12,7 @@ pub struct Chunk {
 }
 
 impl Chunk {
-    fn add_line(&mut self, line: u32) {
+    pub fn add_line(&mut self, line: u32) {
         if let Some(last_line) = self.lines.last_mut() {
             if last_line.line == line {
                 last_line.repeat += 1;

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -34,9 +34,10 @@ impl Compile for Expr {
             Expr::Unary(op, right) => {
                 right.compile(chk);
                 match op.t {
-                    TokenType::Minus  => chk.add_instr(Instruction::Negate, op.pos.line),
+                    TokenType::Minus => chk.add_instr(Instruction::Negate, op.pos.line),
                     TokenType::Plus  => chk.add_instr(Instruction::ToNumber, op.pos.line),
-                    TokenType::Bang => chk.add_instr(Instruction::Not, op.pos.line),
+                    TokenType::Bang  => chk.add_instr(Instruction::Not, op.pos.line),
+                    TokenType::Trace => chk.add_instr(Instruction::Trace, op.pos.line),
                     _ => unimplemented!()
                 }
             }

--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -22,5 +22,7 @@ pub enum Instruction {
     Greater,
     Less,
 
+    Trace,
+
     Return
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -5,6 +5,7 @@ use std::collections::HashMap;
 #[derive(Clone)]
 pub enum BP {
     Zero,
+    KeywordExpr, //trace, return, throw,
     Assignment,
     Or,
     And,
@@ -97,8 +98,15 @@ impl Parser {
         parser.rules.insert(TokenType::LessEqual,
             ParserRule {prefix: None,                   infix: Some(Parser::binary),    bp: BP::Comparison as u8});
 
+        parser.rules.insert(TokenType::Trace,
+            ParserRule {prefix: Some(Parser::unary),    infix: None,                    bp: BP::KeywordExpr as u8});
 
         parser
+    }
+    
+    fn get_rule(&self, t: TokenType) -> ParserRule {
+        let default = ParserRule {prefix: None, infix: None, bp: BP::Zero as u8};
+        self.rules.get(&t).unwrap_or(&default).clone()
     }
 
     fn consume(&mut self, t: TokenType, msg: &'static str) {
@@ -136,11 +144,6 @@ impl Parser {
         let cur = self.toks.peek().clone();
         self.error(cur, "Expected an expression");
         return Expr::Error;
-    }
-
-    fn get_rule(&self, t: TokenType) -> ParserRule {
-        let default = ParserRule {prefix: None, infix: None, bp: BP::Zero as u8};
-        self.rules.get(&t).unwrap_or(&default).clone()
     }
 
     pub fn expr(&mut self) -> Expr {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -99,7 +99,7 @@ impl Parser {
             ParserRule {prefix: None,                   infix: Some(Parser::binary),    bp: BP::Comparison as u8});
 
         parser.rules.insert(TokenType::Trace,
-            ParserRule {prefix: Some(Parser::unary),    infix: None,                    bp: BP::KeywordExpr as u8});
+            ParserRule {prefix: Some(Parser::unarykw),  infix: None,                    bp: BP::KeywordExpr as u8});
 
         parser
     }
@@ -153,6 +153,12 @@ impl Parser {
     fn unary(&mut self) -> Expr {
         let op = self.toks.next();
         let expr = self.parse_bp(BP::Unary as u8);
+        Expr::Unary(op, Box::new(expr))
+    }
+
+    fn unarykw(&mut self) -> Expr {
+        let op = self.toks.next();
+        let expr = self.parse_bp(BP::KeywordExpr as u8);
         Expr::Unary(op, Box::new(expr))
     }
 

--- a/src/token.rs
+++ b/src/token.rs
@@ -91,4 +91,12 @@ impl TokenStream {
     pub fn peek(&self) -> &Token {
         &self.cur
     }
+
+    pub fn nextif(&mut self, t: TokenType) -> bool {
+        if self.peek().t == t {
+            self.next();
+            return true;
+        }
+        return false;
+    }
 }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -186,7 +186,12 @@ impl VM {
                         let a = self.pop_stack();
                         println!("Trace: {:?}", a);
 
+                        let val = a.to_string().unwrap_or("".to_string());
+                        //add filename
+                        let line_no = self.chk.get_line_no(self.cur_instr as u32);
+                        println!("[{}] {}", line_no, val);
                         //maybe don't pop at all?
+
                         self.stack.push(a);
                     },
 

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -289,4 +289,21 @@ mod tests {
 
         assert_eq!(vm.execute(chk), Ok(()));
     }
+
+    #[test]
+    fn test_kwexpr() {
+        let mut chk = Chunk::new();
+        chk.add_line(0);
+        
+        chk.add_const(Value::Number(5.));
+        chk.add_instr(Instruction::PushConstant(0), 0);
+
+        chk.add_instr(Instruction::Trace, 0);
+
+        chk.add_instr(Instruction::Return, 0);
+
+        let mut vm = VM::new();
+
+        assert_eq!(vm.execute(chk), Ok(()));
+    }
 }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -182,6 +182,13 @@ impl VM {
 
                         self.stack.push(Value::Bool(b.is_greater_than(&a)));
                     },
+                    Instruction::Trace => {
+                        let a = self.pop_stack();
+                        println!("Trace: {:?}", a);
+
+                        //maybe don't pop at all?
+                        self.stack.push(a);
+                    },
 
                     #[allow(unreachable_patterns)]
                     _ => unimplemented!()


### PR DESCRIPTION
Implements the `trace <expr>` expression (for #11)