### PR TITLE
if..else epxressions

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -34,14 +34,23 @@ impl std::fmt::Display for Expr {
                 std::fmt::Display::fmt(&**right, f)
             },
             Expr::NullLiteral(tok) => write!(f, "null"),
+            Expr::TrueLiteral(tok) => write!(f, "true"),
+            Expr::FalseLiteral(tok) => write!(f, "false"),
+            Expr::IfElse(cond, if_branch, else_branch) => {
+                write!(f, "if {} -> {}", **cond, **if_branch);
+                if let Some(else_branch) = else_branch {
+                    write!(f, " else {}", **else_branch);
+                }
+                Ok(())
+            },
             Expr::ResolvedBlock(stmts, pop_count) => {
                 writeln!(f, "{{");
                 for stmt in stmts {
                     std::fmt::Display::fmt(&stmt, f);
                     writeln!(f, ";");
                 }
-                writeln!(f, "}}");
-                writeln!(f, "variables popped: {}", pop_count)
+                writeln!(f, "}}")
+                // writeln!(f, "variables popped: {}", pop_count)
             },
             Expr::ResolvedAccess(tok, id) => write!(f, "#{} ({})", id, tok),
             Expr::ResolvedAssign(tok, id, val) => write!(f, "#{} ({}) = {}", id, tok, val),

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -12,6 +12,8 @@ pub enum Expr {
 
     Block(Vec<Stmt>),
 
+    IfElse(Box<Expr>, Box<Expr>, Option<Box<Expr>>),
+
     Access(Token),
 
     ResolvedAccess(Token, u32),

--- a/src/chunk.rs
+++ b/src/chunk.rs
@@ -6,7 +6,7 @@ type LineVec = Vec<LineRL>;
 
 #[derive(Clone)]
 pub struct Chunk {
-    instrs: Vec<Instruction>,
+    pub instrs: Vec<Instruction>,
     consts: Vec<Value>,
     lines: LineVec
 }
@@ -38,13 +38,16 @@ impl Chunk {
         self.consts.get(const_id as usize)
             .expect("The VM failed to access a constant. This might be a problem with the interpreter itself.")
     }
-    pub fn add_instr(&mut self, instr: Instruction, line_no: u32) {
+    pub fn add_instr(&mut self, instr: Instruction, line_no: u32){
         self.instrs.push(instr);
         self.add_line(line_no);
     }
     pub fn get_instr(&self, instr_id: usize) -> &Instruction {
         self.instrs.get(instr_id)
             .expect("The VM failed to access an instruction. This might be a problem with the interpreter itself.")
+    }
+    pub fn set_instr(&mut self, instr_id: usize, set_to: Instruction){
+        self.instrs[instr_id] = set_to;
     }
     pub fn pop_instr(&mut self) -> Instruction {
         self.instrs.pop()

--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -27,5 +27,8 @@ pub enum Instruction {
     PushVariable(u16),
     Assign(u16),
 
+    JumpIfFalse(u16),
+    Jump(u16),
+    JumpPlaceholder,
     Pop, Return
 }

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -90,14 +90,14 @@ impl Resolver {
                 let right = self.resolve_expr(*right)?;
                 Ok(Expr::Unary(op, Box::new(right)))
             },
-            Expr::IfElse(cond, if_branch, else_branch) => {
+            Expr::IfElse(cond, ib, eb) => {
                 let cond = self.resolve_expr(*cond)?;
-                let ifb = self.resolve_expr(*if_branch)?;
-                let mut eb = else_branch;
-                if let Some(else_branch_expr) = eb {
-                    eb = Some(Box::new(self.resolve_expr(*else_branch_expr)?));
+                let ib = self.resolve_expr(*ib)?;
+                let mut eb = eb;
+                if let Some(eb_expr) = eb {
+                    eb = Some(Box::new(self.resolve_expr(*eb_expr)?));
                 }
-                Ok(Expr::IfElse(Box::new(cond), Box::new(ifb), eb))
+                Ok(Expr::IfElse(Box::new(cond), Box::new(ib), eb))
             },
             _ => Ok(expr)
         }

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -90,6 +90,15 @@ impl Resolver {
                 let right = self.resolve_expr(*right)?;
                 Ok(Expr::Unary(op, Box::new(right)))
             },
+            Expr::IfElse(cond, if_branch, else_branch) => {
+                let cond = self.resolve_expr(*cond)?;
+                let ifb = self.resolve_expr(*if_branch)?;
+                let mut eb = else_branch;
+                if let Some(else_branch_expr) = eb {
+                    eb = Some(Box::new(self.resolve_expr(*else_branch_expr)?));
+                }
+                Ok(Expr::IfElse(Box::new(cond), Box::new(ifb), eb))
+            },
             _ => Ok(expr)
         }
     }

--- a/src/value.rs
+++ b/src/value.rs
@@ -34,7 +34,7 @@ impl Value {
             Value::String(s) => return Ok(s.clone()),
             Value::Bool(b) => return Ok((if *b {"true"} else {"false"}).to_string()),
             Value::Number(num) => return Ok(num.to_string()),
-            Value::Null => return Ok("".to_string()),
+            Value::Null => return Ok("null".to_string()),
             _ => return Err("This operand cannot be converted to a string")
         }
     }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -230,6 +230,17 @@ impl VM {
                         let id = *id;
                         let val = self.get_stack_top().clone();
                         self.set_stack(id, val);
+                    },
+                    Instruction::JumpIfFalse(jump_count) => {
+                        let jump_count = *jump_count as usize;
+                        let val = self.pop_stack();
+                        if !val.is_truthy() {
+                            self.cur_instr += jump_count;
+                        }
+                    },
+                    Instruction::Jump(jump_count) => {
+                        let jump_count = *jump_count as usize;
+                        self.cur_instr += jump_count;
                     }
 
                     #[allow(unreachable_patterns)]


### PR DESCRIPTION
Introduces:
- the `if..else` expression pratt parsing
- resolving if condition, if branch, else branch
- compiling and executing
- in the case where there is only the if branch, and it doesn't execute, null is returned in place instead
---
- display traits
- changes `Value#to_string` for null to return `"null"` instead of `""`