### PR TITLE
Functions and closures

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -4,16 +4,16 @@
     // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
     "version": "0.2.0",
     "configurations": [
-    {
-        "name": "(Windows) Launch",
-        "type": "cppvsdbg",
-        "request": "launch",
-        "program": "${workspaceRoot}/target/debug/rsqueso.exe",
-        "args": [],
-        "stopAtEntry": false,
-        "cwd": "${workspaceFolder}",
-        "environment": [],
-        "externalConsole": false
-    }
+        {
+            "name": "(Windows) Launch",
+            "type": "cppvsdbg",
+            "request": "launch",
+            "program": "${workspaceRoot}/target/debug/queso.exe",
+            "args": ["--#instrs"],
+            "stopAtEntry": false,
+            "cwd": "${workspaceRoot}",
+            "environment": [],
+            "externalConsole": true
+        }
     ]
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,6 +142,7 @@ version = "0.1.0"
 dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "phf 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -199,6 +200,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "siphasher"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -224,6 +235,37 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "time"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustversion 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time-macros 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "time-macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro-hack 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time-macros-impl 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "time-macros-impl"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro-hack 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -288,10 +330,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 "checksum rand_hc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 "checksum rand_pcg 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429"
+"checksum rustversion 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b3bba175698996010c4f6dce5e7f173b6eb781fce25d2cfc45e27091ce0b79f6"
 "checksum siphasher 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "83da420ee8d1a89e640d0948c646c1c088758d3a3c538f943bfa97bdac17929d"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 "checksum syn 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)" = "af6f3550d8dff9ef7dc34d384ac6f107e5d31c8f57d9f28e0081503f547ac8f5"
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+"checksum time 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "3043ac959c44dccc548a57417876c8fe241502aed69d880efc91166c02717a93"
+"checksum time-macros 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9ae9b6e9f095bc105e183e3cd493d72579be3181ad4004fceb01adbe9eecab2d"
+"checksum time-macros-impl 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e987cfe0537f575b5fc99909de6185f6c19c3ad8889e2275e686a873d0869ba1"
 "checksum unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479"
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,4 @@ edition = "2018"
 [dependencies]
 phf = { version = "0.8", features = ["macros"] }
 clap = "2.33.0"
+time = "*"

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -63,6 +63,7 @@ impl std::fmt::Display for Expr {
 pub enum Stmt {
     Expr(Box<Expr>),
     MutDecl(Token, Box<Expr>),
+    FnDecl(Token, Box<Expr>),
 
     Error
 }

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -65,7 +65,9 @@ impl std::fmt::Display for Expr {
 pub enum Stmt {
     Expr(Box<Expr>),
     MutDecl(Token, Box<Expr>),
+    ResolvedMutDecl(u16, Box<Expr>),
     FnDecl(Token, Vec<Token>, Box<Expr>),
+    ResolvedFnDecl(Token, u16, Vec<Token>, Box<Expr>),
 
     Error
 }

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -12,6 +12,8 @@ pub enum Expr {
 
     Block(Vec<Stmt>),
 
+    FnCall(Box<Expr>, Vec<Expr>, u16),
+
     IfElse(Box<Expr>, Box<Expr>, Option<Box<Expr>>),
 
     Access(Token),

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -20,7 +20,7 @@ pub enum Expr {
 
     ResolvedAccess(Token, ResolveType),
     ResolvedAssign(Token, ResolveType, Box<Expr>),
-    ResolvedBlock(Vec<Stmt>, u16),
+    ResolvedBlock(Vec<Stmt>),
 
     Error
 }
@@ -45,7 +45,7 @@ impl std::fmt::Display for Expr {
                 }
                 Ok(())
             },
-            Expr::ResolvedBlock(stmts, pop_count) => {
+            Expr::ResolvedBlock(stmts) => {
                 writeln!(f, "{{");
                 for stmt in stmts {
                     std::fmt::Display::fmt(&stmt, f);

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -70,7 +70,7 @@ pub enum Stmt {
     ResolvedFnDecl {
         name: Token,
         id: u16,
-        upvalues: Vec<UpValue>,
+        upvalues: Vec<UpValueIndex>,
         captured: Vec<u16>,
         params: Vec<Token>,
         body: Box<Expr>

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -63,7 +63,7 @@ impl std::fmt::Display for Expr {
 pub enum Stmt {
     Expr(Box<Expr>),
     MutDecl(Token, Box<Expr>),
-    FnDecl(Token, Box<Expr>),
+    FnDecl(Token, Vec<Token>, Box<Expr>),
 
     Error
 }

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -18,7 +18,7 @@ pub enum Expr {
 
     ResolvedAccess(Token, u32),
     ResolvedAssign(Token, u32, Box<Expr>),
-    ResolvedBlock(Vec<Stmt>, u32),
+    ResolvedBlock(Vec<Stmt>, u16),
 
     Error
 }

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -55,6 +55,7 @@ impl std::fmt::Display for Expr {
             },
             Expr::ResolvedAccess(tok, id) => write!(f, "{}", id),
             Expr::ResolvedAssign(tok, id, val) => write!(f, "{} = {}", id, val),
+            Expr::FnCall(_, _, _) => write!(f, "call"),
             _ => panic!("display trait not defined")
         }
     }
@@ -70,6 +71,7 @@ pub enum Stmt {
         name: Token,
         id: u16,
         upvalues: Vec<UpValue>,
+        captured: Vec<u16>,
         params: Vec<Token>,
         body: Box<Expr>
     },
@@ -88,6 +90,7 @@ impl std::fmt::Display for Stmt {
                 name,
                 id,
                 upvalues,
+                captured,
                 params,
                 body
             } => {

--- a/src/callframe.rs
+++ b/src/callframe.rs
@@ -1,11 +1,12 @@
 use crate::*;
 
-pub 
-enum FunctionType {
+#[derive(Debug, Clone)]
+pub enum FunctionType {
     Program,
     Function
 }
 
+#[derive(Debug, Clone)]
 pub struct CallFrame {
     pub func: Function,
     pub funct: FunctionType,
@@ -25,15 +26,12 @@ impl CallFrame {
             stack_base
         }
     }
-}
-
-impl From<Function> for CallFrame {
-    fn from(func: Function) -> CallFrame {
+    pub fn from_function(func: Function, stack_base: usize) -> CallFrame {
         CallFrame {
-            func: func,
+            func,
             funct: FunctionType::Function,
             cur_instr: 0,
-            stack_base: 0
+            stack_base
         }
     }
 }

--- a/src/callframe.rs
+++ b/src/callframe.rs
@@ -19,7 +19,8 @@ impl CallFrame {
         CallFrame {
             clsr: Closure::from_function(Rc::new(Function {
                 chk,
-                name: "".to_string()
+                name: "".to_string(),
+                captured: vec![]
             }), vec![]),
             funct: FunctionType::Program,
             cur_instr: 0,

--- a/src/callframe.rs
+++ b/src/callframe.rs
@@ -17,7 +17,7 @@ pub struct CallFrame {
 impl CallFrame {
     pub fn new(chk: Chunk, stack_base: usize) -> CallFrame {
         CallFrame {
-            clsr: Closure::from_function(Box::new(Function {
+            clsr: Closure::from_function(Rc::new(Function {
                 chk,
                 name: "".to_string()
             })),

--- a/src/callframe.rs
+++ b/src/callframe.rs
@@ -8,7 +8,7 @@ pub enum FunctionType {
 
 #[derive(Debug, Clone)]
 pub struct CallFrame {
-    pub func: Rc<Function>,
+    pub clsr: Closure,
     pub funct: FunctionType,
     pub cur_instr: usize,
     pub stack_base: usize
@@ -17,18 +17,18 @@ pub struct CallFrame {
 impl CallFrame {
     pub fn new(chk: Chunk, stack_base: usize) -> CallFrame {
         CallFrame {
-            func: Rc::new(Function {
+            clsr: Closure::from_function(Box::new(Function {
                 chk,
                 name: "".to_string()
-            }),
+            })),
             funct: FunctionType::Program,
             cur_instr: 0,
             stack_base
         }
     }
-    pub fn from_function(func: Rc<Function>, stack_base: usize) -> CallFrame {
+    pub fn from_closure(clsr: Closure, stack_base: usize) -> CallFrame {
         CallFrame {
-            func,
+            clsr,
             funct: FunctionType::Function,
             cur_instr: 0,
             stack_base

--- a/src/callframe.rs
+++ b/src/callframe.rs
@@ -1,0 +1,17 @@
+use crate::*;
+
+pub struct CallFrame {
+    pub chk: Chunk,
+    pub cur_instr: usize,
+    pub stack_base: usize
+}
+
+impl CallFrame {
+    pub fn new(chk: Chunk, stack_base: usize) -> CallFrame {
+        CallFrame {
+            chk,
+            cur_instr: 0,
+            stack_base
+        }
+    }
+}

--- a/src/callframe.rs
+++ b/src/callframe.rs
@@ -1,6 +1,7 @@
 use crate::*;
 
-pub enum FunctionType {
+pub 
+enum FunctionType {
     Program,
     Function
 }

--- a/src/callframe.rs
+++ b/src/callframe.rs
@@ -8,7 +8,7 @@ pub enum FunctionType {
 
 #[derive(Debug, Clone)]
 pub struct CallFrame {
-    pub func: Function,
+    pub func: Rc<Function>,
     pub funct: FunctionType,
     pub cur_instr: usize,
     pub stack_base: usize
@@ -17,16 +17,16 @@ pub struct CallFrame {
 impl CallFrame {
     pub fn new(chk: Chunk, stack_base: usize) -> CallFrame {
         CallFrame {
-            func: Function {
+            func: Rc::new(Function {
                 chk,
                 name: "".to_string()
-            },
+            }),
             funct: FunctionType::Program,
             cur_instr: 0,
             stack_base
         }
     }
-    pub fn from_function(func: Function, stack_base: usize) -> CallFrame {
+    pub fn from_function(func: Rc<Function>, stack_base: usize) -> CallFrame {
         CallFrame {
             func,
             funct: FunctionType::Function,

--- a/src/callframe.rs
+++ b/src/callframe.rs
@@ -20,7 +20,7 @@ impl CallFrame {
             clsr: Closure::from_function(Rc::new(Function {
                 chk,
                 name: "".to_string()
-            })),
+            }), vec![]),
             funct: FunctionType::Program,
             cur_instr: 0,
             stack_base

--- a/src/callframe.rs
+++ b/src/callframe.rs
@@ -1,7 +1,13 @@
 use crate::*;
 
+pub enum FunctionType {
+    Program,
+    Function
+}
+
 pub struct CallFrame {
-    pub chk: Chunk,
+    pub func: Function,
+    pub funct: FunctionType,
     pub cur_instr: usize,
     pub stack_base: usize
 }
@@ -9,9 +15,24 @@ pub struct CallFrame {
 impl CallFrame {
     pub fn new(chk: Chunk, stack_base: usize) -> CallFrame {
         CallFrame {
-            chk,
+            func: Function {
+                chk,
+                name: "".to_string()
+            },
+            funct: FunctionType::Program,
             cur_instr: 0,
             stack_base
+        }
+    }
+}
+
+impl From<Function> for CallFrame {
+    fn from(func: Function) -> CallFrame {
+        CallFrame {
+            func: func,
+            funct: FunctionType::Function,
+            cur_instr: 0,
+            stack_base: 0
         }
     }
 }

--- a/src/chunk.rs
+++ b/src/chunk.rs
@@ -80,6 +80,17 @@ impl Chunk {
             self.print_instr(i, true);
         }
     }
+    pub fn print_debug(&self, name: &String) {
+        println!("== {} ==", name);
+        print!("consts ");
+        for c in self.consts.clone() {
+            print!("| {:?}", c);
+        }
+        println!();
+        for i in 0..self.instrs.len() {
+            self.print_instr(i, true);
+        }
+    }
     pub fn print_instr(&self, instr_id: usize, hide_repeating_lines: bool) {
         // print!("{:<4} ", 
         //     if instr_id >= 1

--- a/src/chunk.rs
+++ b/src/chunk.rs
@@ -79,15 +79,15 @@ impl Chunk {
         }
     }
     pub fn print_instr(&self, instr_id: usize, hide_repeating_lines: bool) {
-        print!("{:<4} ", 
-            if instr_id >= 1
-            && self.get_line_no(instr_id as u32) == self.get_line_no((instr_id-1) as u32)
-            && hide_repeating_lines {
-                "".to_string()
-            } else {
-                self.get_line_no(instr_id as u32).to_string()
-            }
-        );
+        // print!("{:<4} ", 
+        //     if instr_id >= 1
+        //     && self.get_line_no(instr_id as u32) == self.get_line_no((instr_id-1) as u32)
+        //     && hide_repeating_lines {
+        //         "".to_string()
+        //     } else {
+        //         self.get_line_no(instr_id as u32).to_string()
+        //     }
+        // );
         self.print_instr_info(&self.get_instr(instr_id));
     }
     pub fn print_instr_info(&self, instr: &Instruction) {

--- a/src/chunk.rs
+++ b/src/chunk.rs
@@ -1,10 +1,10 @@
 use crate::*;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct LineRL {pub line: u32, pub repeat: u16}
 type LineVec = Vec<LineRL>;
 
-#[derive(Clone)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct Chunk {
     pub instrs: Vec<Instruction>,
     consts: Vec<Value>,

--- a/src/chunk.rs
+++ b/src/chunk.rs
@@ -84,7 +84,7 @@ impl Chunk {
         println!("== {} ==", name);
         print!("consts ");
         for c in self.consts.clone() {
-            print!("| {:?}", c);
+            print!("| {}", c);
         }
         println!();
         for i in 0..self.instrs.len() {
@@ -105,7 +105,7 @@ impl Chunk {
     }
     pub fn print_instr_info(&self, instr: &Instruction) {
         match instr {
-            Instruction::PushConstant (id) => println!("{:?}, value: {:?}", instr, self.get_const(*id)),
+            Instruction::PushConstant (id) => println!("{:?}, value: {}", instr, self.get_const(*id)),
             _ => println!("{:?}", instr)
         };
     }

--- a/src/chunk.rs
+++ b/src/chunk.rs
@@ -8,6 +8,7 @@ type LineVec = Vec<LineRL>;
 pub struct Chunk {
     pub instrs: Vec<Instruction>,
     consts: Vec<Value>,
+    pub var_count: u16,
     lines: LineVec
 }
 
@@ -27,6 +28,7 @@ impl Chunk {
         Chunk {
             instrs: Vec::<Instruction>::new(),
             consts: Vec::<Value>::new(),
+            var_count: 0,
             lines: LineVec::new()
         }
     }

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -140,7 +140,7 @@ impl<'a> Compiler<'a> {
                 self.chk.add_instr(Instruction::FnCall(pop_count), 0);
             },
 
-            Expr::ResolvedBlock(stmts, pop_count) => {
+            Expr::ResolvedBlock(stmts) => {
                 self.compile_stmts_with_return(stmts);
             },
             Expr::ResolvedAccess(name, id) => {

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -112,6 +112,13 @@ impl<'a> Compiler<'a> {
                 self.label_jump(jump_b);
 
             },
+            Expr::FnCall(left, args, pop_count) => {
+                self.compile_expr(*left);
+                for arg in args {
+                    self.compile_expr(arg);
+                }
+                self.chk.add_instr(Instruction::FnCall(pop_count), 0);
+            },
 
             Expr::ResolvedBlock(stmts, pop_count) => {
                 self.compile_stmts_with_return(stmts);
@@ -148,11 +155,13 @@ impl<'a> Compiler<'a> {
             Stmt::MutDecl(name, val) => {
                 self.compile_expr(*val);
             },
-            Stmt::FnDecl(name, params, body) => {
+            Stmt::FnDecl(name, _, body) => {
                 let mut chk = Chunk::new();
                 let mut compiler = Compiler::new(&mut chk);
 
                 compiler.compile_expr(*body);
+                chk.add_instr(Instruction::Return, 0);
+
                 let func = Function {
                     chk,
                     name: name.val

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -138,11 +138,11 @@ impl<'a> Compiler<'a> {
             Expr::ResolvedBlock(stmts, pop_count) => {
                 self.compile_stmts_with_return(stmts);
             },
-            Expr::ResolvedAccess(name, id) => self.chk.add_instr(Instruction::PushVariable(id as u16), name.pos.line),
-            Expr::ResolvedAssign(name, id, val) => {
-                self.compile_expr(*val);
-                self.chk.add_instr(Instruction::Assign(id as u16), name.pos.line)
-            },
+            // Expr::ResolvedAccess(name, id) => self.chk.add_instr(Instruction::PushVariable(id as u16), name.pos.line),
+            // Expr::ResolvedAssign(name, id, val) => {
+            //     self.compile_expr(*val);
+            //     self.chk.add_instr(Instruction::Assign(id as u16), name.pos.line)
+            // },
             _ => panic!("This is a problem with the compiler itself")
         }
 
@@ -171,12 +171,19 @@ impl<'a> Compiler<'a> {
                 self.compile_expr(*val);
                 self.chk.add_instr(Instruction::DeclareAssign(id), 0)
             },
-            Stmt::ResolvedFnDecl(name, id, _, body) => {
+            Stmt::ResolvedFnDecl {
+                name,
+                id,
+                upvalues,
+                params,
+                body
+            } => {
                 self.chk.var_count += 1;
                 let mut chk = Chunk::new();
                 let mut compiler = Compiler::new(&mut chk);
 
                 compiler.compile_func(*body);
+                chk.print_debug(&name.val);
 
                 let func = Function {
                     chk,

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -41,7 +41,13 @@ impl<'a> Compiler<'a> {
         self.patch_reserve(reserve_id);
         self.chk.add_instr(Instruction::Return, 0);
     }
-    pub fn compile_expr(&mut self, expr: Expr) {
+    pub fn compile_func(&mut self, expr: Expr) {
+        let reserve_id = self.make_reserve();
+        self.compile_expr(expr);
+        self.patch_reserve(reserve_id);
+        self.chk.add_instr(Instruction::Return, 0);
+    }
+    fn compile_expr(&mut self, expr: Expr) {
         match expr {
             Expr::Constant(tok) => {
                 let const_id = self.chk.add_const(Value::from(&tok));
@@ -170,16 +176,14 @@ impl<'a> Compiler<'a> {
                 let mut chk = Chunk::new();
                 let mut compiler = Compiler::new(&mut chk);
 
-                compiler.compile_expr(*body);
-                chk.add_instr(Instruction::Return, 0);
+                compiler.compile_func(*body);
+                chk.print("fn");
 
                 let func = Function {
                     chk,
                     name: name.val
                 };
                 let const_id = self.chk.add_const(Value::Function(Rc::new(func)));
-                self.chk.add_instr(Instruction::PushConstant(const_id), 0);
-                self.chk.add_instr(Instruction::DeclareAssign(id), 0);
                 self.chk.add_instr(Instruction::DeclareAssignConstant(id, const_id), 0)
             }
             _ => panic!("This is a problem with the compiler itself")

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -197,6 +197,7 @@ impl<'a> Compiler<'a> {
                 name,
                 id,
                 upvalues,
+                captured,
                 params,
                 body
             } => {
@@ -209,7 +210,8 @@ impl<'a> Compiler<'a> {
 
                 let func = Function {
                     chk,
-                    name: name.val
+                    name: name.val,
+                    captured
                 };
                 let const_id = self.chk.add_const(Value::Function(Rc::new(func)));
 

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -149,7 +149,7 @@ impl<'a> Compiler<'a> {
                         self.chk.add_instr(Instruction::GetLocal(id as u16), name.pos.line)
                     },
                     ResolveType::UpValue {id} => {
-                        self.chk.add_instr(Instruction::GetCaptured(id as u16), name.pos.line)
+                        self.chk.add_instr(Instruction::GetUpValue(id as u16), name.pos.line)
                     },
                 }
             },
@@ -161,7 +161,7 @@ impl<'a> Compiler<'a> {
                         self.chk.add_instr(Instruction::SetLocal(id as u16), name.pos.line)
                     },
                     ResolveType::UpValue {id} => {
-                        self.chk.add_instr(Instruction::SetCaptured(id as u16), name.pos.line)
+                        self.chk.add_instr(Instruction::SetUpValue(id as u16), name.pos.line)
                     },
                 }
             },
@@ -241,7 +241,7 @@ mod tests {
         let mut compiler = Compiler::new(&mut chk);
         compiler.compile(program);
 
-        assert_eq!(chk.get_const(0).clone(), Value::Number(1.23));
+        // assert_eq!(chk.get_const(0).clone(), Value::Number(1.23));
         assert_eq!(chk.get_line_no(0), 1);
     }
 

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -182,7 +182,7 @@ impl<'a> Compiler<'a> {
                     chk,
                     name: name.val
                 };
-                let const_id = self.chk.add_const(Value::Function(Box::new(func)));
+                let const_id = self.chk.add_const(Value::Function(Rc::new(func)));
                 // self.chk.add_instr(Instruction::DeclareAssignConstant(id, const_id), 0)
                 self.chk.add_instr(Instruction::Closure(id, const_id), 0)
             }

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -166,7 +166,7 @@ impl<'a> Compiler<'a> {
                     chk,
                     name: name.val
                 };
-                let const_id = self.chk.add_const(Value::Function(Box::new(func)));
+                let const_id = self.chk.add_const(Value::Function(Rc::new(func)));
                 self.chk.add_instr(Instruction::PushConstant(const_id), 0);
             }
             _ => panic!("This is a problem with the compiler itself")

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -32,7 +32,7 @@ impl<'a> Compiler<'a> {
         };
         self.chk.add_instr(Instruction::Return, 0);
     }
-    fn compile_expr(&mut self, expr: Expr) {
+    pub fn compile_expr(&mut self, expr: Expr) {
         match expr {
             Expr::Constant(tok) => {
                 let const_id = self.chk.add_const(Value::from(&tok));
@@ -148,6 +148,18 @@ impl<'a> Compiler<'a> {
             Stmt::MutDecl(name, val) => {
                 self.compile_expr(*val);
             },
+            Stmt::FnDecl(name, body) => {
+                let mut chk = Chunk::new();
+                let mut compiler = Compiler::new(&mut chk);
+
+                compiler.compile_expr(*body);
+                let func = Function {
+                    chk,
+                    name: name.val
+                };
+                let const_id = self.chk.add_const(Value::Function(Box::new(func)));
+                self.chk.add_instr(Instruction::PushConstant(const_id), 0);
+            }
             _ => panic!("This is a problem with the compiler itself")
         }
     }

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -148,7 +148,7 @@ impl<'a> Compiler<'a> {
             Stmt::MutDecl(name, val) => {
                 self.compile_expr(*val);
             },
-            Stmt::FnDecl(name, body) => {
+            Stmt::FnDecl(name, params, body) => {
                 let mut chk = Chunk::new();
                 let mut compiler = Compiler::new(&mut chk);
 

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -177,14 +177,14 @@ impl<'a> Compiler<'a> {
                 let mut compiler = Compiler::new(&mut chk);
 
                 compiler.compile_func(*body);
-                chk.print("fn");
 
                 let func = Function {
                     chk,
                     name: name.val
                 };
-                let const_id = self.chk.add_const(Value::Function(Rc::new(func)));
-                self.chk.add_instr(Instruction::DeclareAssignConstant(id, const_id), 0)
+                let const_id = self.chk.add_const(Value::Function(Box::new(func)));
+                // self.chk.add_instr(Instruction::DeclareAssignConstant(id, const_id), 0)
+                self.chk.add_instr(Instruction::Closure(id, const_id), 0)
             }
             _ => panic!("This is a problem with the compiler itself")
         }

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -31,7 +31,12 @@ impl<'a> Compiler<'a> {
         self.chk.instrs.len() - 1
     }
     fn patch_reserve(&mut self, instr_id: usize) {
-        self.chk.set_instr(instr_id, Instruction::Reserve(self.chk.var_count));
+        if self.chk.var_count > 0 {
+            self.chk.set_instr(instr_id, Instruction::Reserve(self.chk.var_count));
+        }
+        else {
+            self.chk.instrs.remove(instr_id);
+        }
     } 
     pub fn compile(&mut self, program: Program) {
         let reserve_id = self.make_reserve();

--- a/src/env.rs
+++ b/src/env.rs
@@ -21,7 +21,7 @@ impl Env {
     pub fn open(&mut self) {
         self.scope_depth+=1
     }
-    pub fn close(&mut self) -> u32 {
+    pub fn close(&mut self) -> u16 {
         let mut pop_count = 0;
         while self.locals.len()!=0 {
             if self.locals.last().expect("This is a problem with the compiler itself").depth == self.scope_depth {

--- a/src/env.rs
+++ b/src/env.rs
@@ -3,8 +3,7 @@ use crate::*;
 pub struct Env {
     pub locals: Vec<Local>,
     pub upvalues: Vec<UpValue>,
-    pub scope_depth: u8,
-    pub is_function: bool
+    pub scope_depth: u8
 }
 
 impl Env {
@@ -13,20 +12,11 @@ impl Env {
             locals: Vec::<Local>::new(),
             upvalues: Vec::<UpValue>::new(),
             scope_depth: 0,
-            is_function: false
-        }
-    }
-    pub fn new_function() -> Env {
-        Env {
-            locals: Vec::<Local>::new(),
-            upvalues: Vec::<UpValue>::new(),
-            scope_depth: 0,
-            is_function: true
         }
     }
     pub fn add_local(&mut self, name: Token) -> u16 {
         self.locals.push(Local {name, depth: self.scope_depth as u8});
-        self.locals.len() as u16 - 1 + self.is_function as u16
+        self.locals.len() as u16 - 1
     }
     pub fn add_upvalue(&mut self, upvalue: UpValue) -> u16 {
         for (i, upv) in self.upvalues.iter().enumerate() {
@@ -71,10 +61,6 @@ impl Env {
             i -= 1;
         }
         return false
-    }
-
-    pub fn add_func_offset<T: From<bool> + std::ops::Add<Output = T>>(&self, id: T) -> T {
-        T::from(self.is_function) + id
     }
 }
 

--- a/src/env.rs
+++ b/src/env.rs
@@ -70,7 +70,7 @@ pub struct Local {
     pub depth: u8
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct UpValue {
     pub id: u16,
     pub is_local: bool

--- a/src/env.rs
+++ b/src/env.rs
@@ -1,8 +1,8 @@
 use crate::*;
 
 pub struct Env {
-    pub locals: Vec<Local>,
-    pub upvalues: Vec<UpValue>,
+    pub locals: Vec<LocalIndex>,
+    pub upvalues: Vec<UpValueIndex>,
     pub captured: Vec<u16>,
     pub scope_depth: u8
 }
@@ -10,17 +10,17 @@ pub struct Env {
 impl Env {
     pub fn new() -> Env {
         Env {
-            locals: Vec::<Local>::new(),
-            upvalues: Vec::<UpValue>::new(),
+            locals: Vec::<LocalIndex>::new(),
+            upvalues: Vec::<UpValueIndex>::new(),
             captured: Vec::<u16>::new(),
             scope_depth: 0,
         }
     }
     pub fn add_local(&mut self, name: Token) -> u16 {
-        self.locals.push(Local {name, depth: self.scope_depth as u8});
+        self.locals.push(LocalIndex {name, depth: self.scope_depth as u8});
         self.locals.len() as u16 - 1
     }
-    pub fn add_upvalue(&mut self, upvalue: UpValue) -> u16 {
+    pub fn add_upvalue(&mut self, upvalue: UpValueIndex) -> u16 {
         for (i, upv) in self.upvalues.iter().enumerate() {
             if upv.id == upvalue.id && upv.is_local == upvalue.is_local {
                 return i as u16;
@@ -29,7 +29,7 @@ impl Env {
         self.upvalues.push(upvalue);
         self.upvalues.len() as u16 - 1
     }
-    pub fn get(&self, id: usize) -> &Local {
+    pub fn get(&self, id: usize) -> &LocalIndex {
         self.locals.get(id).expect("This is a problem with the compiler itself")
     }
     pub fn open(&mut self) {
@@ -71,13 +71,13 @@ impl Env {
 }
 
 #[derive(Debug)]
-pub struct Local {
+pub struct LocalIndex {
     pub name: Token,
     pub depth: u8
 }
 
 #[derive(Debug, Clone, PartialEq)]
-pub struct UpValue {
+pub struct UpValueIndex {
     pub id: u16,
     pub is_local: bool
 }

--- a/src/env.rs
+++ b/src/env.rs
@@ -35,7 +35,7 @@ impl Env {
             }
         }
         self.upvalues.push(upvalue);
-        self.upvalues.len() as u16 - 1 + self.is_function as u16
+        self.upvalues.len() as u16 - 1
     }
     pub fn get(&self, id: usize) -> &Local {
         self.locals.get(id).expect("This is a problem with the compiler itself")
@@ -71,6 +71,10 @@ impl Env {
             i -= 1;
         }
         return false
+    }
+
+    pub fn add_func_offset<T: From<bool> + std::ops::Add<Output = T>>(&self, id: T) -> T {
+        T::from(self.is_function) + id
     }
 }
 

--- a/src/env.rs
+++ b/src/env.rs
@@ -35,17 +35,8 @@ impl Env {
     pub fn open(&mut self) {
         self.scope_depth+=1
     }
-    pub fn close(&mut self) -> u16 {
-        let mut pop_count = 0;
-        while self.locals.len()!=0 {
-            if self.locals.last().expect("This is a problem with the compiler itself").depth == self.scope_depth {
-                self.locals.pop();
-                pop_count +=1;
-            }
-            else {break;}
-        }
+    pub fn close(&mut self) {
         self.scope_depth-=1;
-        pop_count
     }
 
     pub fn is_redefined(&self, other: &Token) -> bool {

--- a/src/env.rs
+++ b/src/env.rs
@@ -3,6 +3,7 @@ use crate::*;
 pub struct Env {
     pub locals: Vec<Local>,
     pub upvalues: Vec<UpValue>,
+    pub captured: Vec<u16>,
     pub scope_depth: u8
 }
 
@@ -11,6 +12,7 @@ impl Env {
         Env {
             locals: Vec::<Local>::new(),
             upvalues: Vec::<UpValue>::new(),
+            captured: Vec::<u16>::new(),
             scope_depth: 0,
         }
     }
@@ -61,6 +63,10 @@ impl Env {
             i -= 1;
         }
         return false
+    }
+
+    pub fn capture(&mut self, id: u16) {
+        self.captured.push(id);
     }
 }
 

--- a/src/env.rs
+++ b/src/env.rs
@@ -2,18 +2,40 @@ use crate::*;
 
 pub struct Env {
     pub locals: Vec<Local>,
-    pub scope_depth: u8
+    pub upvalues: Vec<UpValue>,
+    pub scope_depth: u8,
+    pub is_function: bool
 }
 
 impl Env {
     pub fn new() -> Env {
         Env {
             locals: Vec::<Local>::new(),
-            scope_depth: 0
+            upvalues: Vec::<UpValue>::new(),
+            scope_depth: 0,
+            is_function: false
         }
     }
-    pub fn add(&mut self, name: Token) {
+    pub fn new_function() -> Env {
+        Env {
+            locals: Vec::<Local>::new(),
+            upvalues: Vec::<UpValue>::new(),
+            scope_depth: 0,
+            is_function: true
+        }
+    }
+    pub fn add_local(&mut self, name: Token) -> u16 {
         self.locals.push(Local {name, depth: self.scope_depth as u8});
+        self.locals.len() as u16 - 1 + self.is_function as u16
+    }
+    pub fn add_upvalue(&mut self, upvalue: UpValue) -> u16 {
+        for (i, upv) in self.upvalues.iter().enumerate() {
+            if upv.id == upvalue.id && upv.is_local == upvalue.is_local {
+                return i as u16;
+            }
+        }
+        self.upvalues.push(upvalue);
+        self.upvalues.len() as u16 - 1 + self.is_function as u16
     }
     pub fn get(&self, id: usize) -> &Local {
         self.locals.get(id).expect("This is a problem with the compiler itself")
@@ -56,4 +78,10 @@ impl Env {
 pub struct Local {
     pub name: Token,
     pub depth: u8
+}
+
+#[derive(Debug, Clone)]
+pub struct UpValue {
+    pub id: u16,
+    pub is_local: bool
 }

--- a/src/fn.rs
+++ b/src/fn.rs
@@ -1,0 +1,4 @@
+pub struct Fn {
+    pub chk: Chunk,
+    pub name: String,
+}

--- a/src/fn.rs
+++ b/src/fn.rs
@@ -1,4 +1,0 @@
-pub struct Fn {
-    pub chk: Chunk,
-    pub name: String,
-}

--- a/src/function.rs
+++ b/src/function.rs
@@ -10,11 +10,11 @@ pub struct Function {
 #[derive(Clone, PartialEq, Debug)]
 pub struct Closure {
     pub func: Rc<Function>,
-    pub upvalues: Vec<UpValue>
+    pub upvalues: Vec<MutRc<UpValue>>
 }
 
 impl Closure {
-    pub fn from_function(func: Rc<Function>, upvalues: Vec<UpValue>) -> Closure {
+    pub fn from_function(func: Rc<Function>, upvalues: Vec<MutRc<UpValue>>) -> Closure {
         Closure {
             func,
             upvalues

--- a/src/function.rs
+++ b/src/function.rs
@@ -5,3 +5,16 @@ pub struct Function {
     pub chk: Chunk,
     pub name: String,
 }
+
+#[derive(Clone, PartialEq, Debug)]
+pub struct Closure {
+    pub func: Rc<Function>
+}
+
+impl Closure {
+    pub fn from_function(func: Box<Function>) -> Closure {
+        Closure {
+            func: Rc::from(func)
+        }
+    }
+}

--- a/src/function.rs
+++ b/src/function.rs
@@ -12,9 +12,9 @@ pub struct Closure {
 }
 
 impl Closure {
-    pub fn from_function(func: Box<Function>) -> Closure {
+    pub fn from_function(func: Rc<Function>) -> Closure {
         Closure {
-            func: Rc::from(func)
+            func
         }
     }
 }

--- a/src/function.rs
+++ b/src/function.rs
@@ -1,0 +1,7 @@
+use crate::*;
+
+#[derive(Clone, PartialEq, Debug)]
+pub struct Function {
+    pub chk: Chunk,
+    pub name: String,
+}

--- a/src/function.rs
+++ b/src/function.rs
@@ -8,13 +8,15 @@ pub struct Function {
 
 #[derive(Clone, PartialEq, Debug)]
 pub struct Closure {
-    pub func: Rc<Function>
+    pub func: Rc<Function>,
+    pub captured: Vec<*mut Value>
 }
 
 impl Closure {
-    pub fn from_function(func: Rc<Function>) -> Closure {
+    pub fn from_function(func: Rc<Function>, captured: Vec<*mut Value>) -> Closure {
         Closure {
-            func
+            func,
+            captured
         }
     }
 }

--- a/src/function.rs
+++ b/src/function.rs
@@ -10,14 +10,14 @@ pub struct Function {
 #[derive(Clone, PartialEq, Debug)]
 pub struct Closure {
     pub func: Rc<Function>,
-    pub captured: Vec<*mut Value>
+    pub upvalues: Vec<UpValue>
 }
 
 impl Closure {
-    pub fn from_function(func: Rc<Function>, captured: Vec<*mut Value>) -> Closure {
+    pub fn from_function(func: Rc<Function>, upvalues: Vec<UpValue>) -> Closure {
         Closure {
             func,
-            captured
+            upvalues
         }
     }
 }

--- a/src/function.rs
+++ b/src/function.rs
@@ -4,6 +4,7 @@ use crate::*;
 pub struct Function {
     pub chk: Chunk,
     pub name: String,
+    pub captured: Vec<u16>
 }
 
 #[derive(Clone, PartialEq, Debug)]

--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -27,6 +27,7 @@ pub enum Instruction {
     PushVariable(u16),
     Assign(u16),
 
+    EndBlock(u16),
     JumpIfFalsy(u16),
     PopAndJumpIfFalsy(u16), //always pop, that is
     JumpIfTruthy(u16),

--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -25,13 +25,13 @@ pub enum Instruction {
     Trace,
 
     GetLocal(u16),
-    GetCaptured(u16),
+    GetUpValue(u16),
     SetLocal(u16),
-    SetCaptured(u16),
+    SetUpValue(u16),
     Declare(u16),
 
     FnCall(u16),
-    Closure(u16, u16, Vec<UpValue>), //assignid, constid
+    Closure(u16, u16, Vec<UpValueIndex>), //assignid, constid
 
     JumpIfFalsy(u16),
     PopAndJumpIfFalsy(u16), //always pop, that is

--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -26,13 +26,17 @@ pub enum Instruction {
 
     PushVariable(u16),
     Assign(u16),
+    DeclareAssign(u16),
+    DeclareAssignConstant(u16, u16), //assignid, constid
     FnCall(u16),
 
-    EndBlock(u16),
     JumpIfFalsy(u16),
     PopAndJumpIfFalsy(u16), //always pop, that is
     JumpIfTruthy(u16),
     Jump(u16),
     JumpPlaceholder,
-    Pop, Return
+    Pop, Return,
+
+    ReservePlaceholder,
+    Reserve(u16)
 }

--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -24,12 +24,14 @@ pub enum Instruction {
 
     Trace,
 
-    PushVariable(u16),
-    Assign(u16),
-    DeclareAssign(u16),
-    DeclareAssignConstant(u16, u16), //assignid, constid
+    GetLocal(u16),
+    GetCaptured(u16),
+    SetLocal(u16),
+    SetCaptured(u16),
+    Declare(u16),
+    
     FnCall(u16),
-    Closure(u16, u16), //assignid, constid
+    Closure(u16, u16, Vec<UpValue>), //assignid, constid
 
     JumpIfFalsy(u16),
     PopAndJumpIfFalsy(u16), //always pop, that is

--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -29,7 +29,7 @@ pub enum Instruction {
     SetLocal(u16),
     SetCaptured(u16),
     Declare(u16),
-    
+
     FnCall(u16),
     Closure(u16, u16, Vec<UpValue>), //assignid, constid
 

--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -29,6 +29,7 @@ pub enum Instruction {
     DeclareAssign(u16),
     DeclareAssignConstant(u16, u16), //assignid, constid
     FnCall(u16),
+    Closure(u16, u16), //assignid, constid
 
     JumpIfFalsy(u16),
     PopAndJumpIfFalsy(u16), //always pop, that is

--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -26,6 +26,7 @@ pub enum Instruction {
 
     PushVariable(u16),
     Assign(u16),
+    FnCall(u16),
 
     EndBlock(u16),
     JumpIfFalsy(u16),

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -8,7 +8,7 @@ static KEYWORDS: phf::Map<&'static str, TokenType> = phf_map! {
      "trace" => TokenType::Trace, "return" => TokenType::Return, "in" => TokenType::In, "catch" => TokenType::Catch,
      "this" => TokenType::This, "prv" => TokenType::Prv, "static" => TokenType::Static, "new" => TokenType::New, "base" => TokenType::Base,
      "emit" => TokenType::Emit, "on" => TokenType::On,
-     "true" => TokenType::True, "false" => TokenType::False
+     "true" => TokenType::True, "false" => TokenType::False, "null" => TokenType::Null
 };
 
 #[derive(Clone)]
@@ -74,7 +74,6 @@ impl Lexer {
             '}' => self.new_token(TokenType::RightBrace),
 
             ';' => self.new_token(TokenType::Semi),
-            '~' => self.new_token(TokenType::Null),
             '+' => self.new_token(TokenType::Plus),
             ',' => self.new_token(TokenType::Comma),
             '.' => self.new_token(TokenType::Dot),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,6 @@
 #![allow(dead_code)]
 #![allow(unused)]
 
-// extern crate time;
-// use time::PreciseTime;
-
 use std::io::{self, Read};
 use std::rc::Rc;
 
@@ -64,7 +61,6 @@ struct QuesoOpts {
 
 
 fn main() {
-    println!("test {}", std::mem::size_of::<Instruction>());
     let matches = App::new("queso")
        .version(crate_version!())
        .about("The interpreter for the queso language")
@@ -159,12 +155,11 @@ fn run(opts: QuesoOpts, src: String) -> bool {
         let mut vm = VM::new(chk, opts.debug.instrs);
 
 
-        use std::time::{Instant};
+        use std::time::Instant;
         let now = Instant::now();
         let res = vm.execute();
         let new_now = Instant::now();
         println!("{:?}", new_now.duration_since(now));
-        println!("{:?}", vm.time);
         
         
         match res {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,11 @@
 #![allow(dead_code)]
 #![allow(unused)]
+
+// extern crate time;
+// use time::PreciseTime;
+
 use std::io::{self, Read};
+use std::rc::Rc;
 
 mod token;
 use token::*;
@@ -59,6 +64,7 @@ struct QuesoOpts {
 
 
 fn main() {
+    println!("test {}", std::mem::size_of::<Instruction>());
     let matches = App::new("queso")
        .version(crate_version!())
        .about("The interpreter for the queso language")
@@ -151,7 +157,16 @@ fn run(opts: QuesoOpts, src: String) -> bool {
         compiler.compile(program);
 
         let mut vm = VM::new(chk, opts.debug.instrs);
+
+
+        use std::time::{Instant};
+        let now = Instant::now();
         let res = vm.execute();
+        let new_now = Instant::now();
+        println!("{:?}", new_now.duration_since(now));
+        println!("{:?}", vm.time);
+        
+        
         match res {
             Err(err) => println!("{}", err),
             _ => {}

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,8 +38,11 @@ use env::*;
 mod resolver;
 use resolver::*;
 
-mod fn;
-use fn::*;
+mod function;
+use function::*;
+
+mod callframe;
+use callframe::*;
 
 extern crate clap; 
 use clap::{App, Arg, crate_version};
@@ -147,8 +150,8 @@ fn run(opts: QuesoOpts, src: String) -> bool {
         let mut compiler = Compiler::new(&mut chk);
         compiler.compile(program);
 
-        let mut vm = VM::new(opts.debug.instrs);
-        let res = vm.execute(chk);
+        let mut vm = VM::new(chk, opts.debug.instrs);
+        let res = vm.execute();
         match res {
             Err(err) => println!("{}", err),
             _ => {}

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,6 +46,9 @@ use function::*;
 mod callframe;
 use callframe::*;
 
+mod upvalue;
+use upvalue::*;
+
 extern crate clap; 
 use clap::{App, Arg, crate_version};
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,9 @@
 #![allow(dead_code)]
 #![allow(unused)]
 
+use std::cell::RefCell;
+pub type MutRc<T> = Rc<RefCell<T>>;
+
 use std::io::{self, Read};
 use std::rc::Rc;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,6 +38,9 @@ use env::*;
 mod resolver;
 use resolver::*;
 
+mod fn;
+use fn::*;
+
 extern crate clap; 
 use clap::{App, Arg, crate_version};
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -311,12 +311,23 @@ impl Parser {
         self.consume(TokenType::Identifier, "Expected function name");
 
         self.consume(TokenType::LeftParen, "Expected ( after function name");
+
+        let mut params = Vec::<Token>::new();
+        if self.toks.peek().t != TokenType::RightParen {
+            loop {
+                params.push(self.toks.peek().clone());
+                self.consume(TokenType::Identifier, "Expected parameter name");
+
+                if !self.toks.nextif(TokenType::Comma) {break;}
+            }
+        }
+
         self.consume(TokenType::RightParen, "Expected ) after parameters");
 
         self.consume(TokenType::Colon, "Expected :");
 
         let body = self.expr();
-        Stmt::FnDecl(name, Box::new(body))
+        Stmt::FnDecl(name, params, Box::new(body))
     }
 }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -283,13 +283,11 @@ impl Parser {
             else {self.sync()};
         }
         
-        let stmt: Stmt;
         match self.toks.peek().t {
-            TokenType::Mut => stmt = self.mut_decl(),
-            _ => stmt = self.expr_stmt()
+            TokenType::Mut => self.mut_decl(),
+            TokenType::Fn => self.fn_decl(),
+            _ => self.expr_stmt()
         }
-
-        stmt
     }
     fn expr_stmt(&mut self) -> Stmt {
         let stmt = Stmt::Expr(Box::new(self.expr()));
@@ -306,6 +304,19 @@ impl Parser {
         }
 
         Stmt::MutDecl(name, Box::new(val))
+    }
+    fn fn_decl(&mut self) -> Stmt {
+        self.toks.next();
+        let name = self.toks.peek().clone();
+        self.consume(TokenType::Identifier, "Expected function name");
+
+        self.consume(TokenType::LeftParen, "Expected ( after function name");
+        self.consume(TokenType::RightParen, "Expected ) after parameters");
+
+        self.consume(TokenType::Colon, "Expected :");
+
+        let body = self.expr();
+        Stmt::FnDecl(name, Box::new(body))
     }
 }
 

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -53,6 +53,14 @@ impl Resolver {
             Stmt::Expr(expr) => {
                 Ok(Stmt::Expr(Box::new(self.resolve_expr(*expr)?)))
             },
+            Stmt::FnDecl(name, body) => {
+                let body = self.resolve_expr(*body)?;
+                if self.env.is_redefined(&name) {
+                    return Err("Tried to redeclare a variable in the same scope");
+                }
+                self.env.add(name.clone());
+                Ok(Stmt::FnDecl(name, Box::new(body)))
+            },
             _ => panic!()
         }
     }

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -1,20 +1,81 @@
 use crate::*;
 
+#[derive(Debug, Clone)]
+pub enum ResolveType {
+    Local {id: u16}, //id = slot in frame
+    UpValue {id: u16} //id = slot in closure's upvalue array
+}
+impl std::fmt::Display for ResolveType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ResolveType::Local {id} => write!(f, "#{}", id),
+            ResolveType::UpValue {id} => write!(f, "^{}", id)
+        }
+    }
+}
+
 pub struct Resolver {
-    env: Env
+    pub list: Vec<ResolverNode>,
+    cur: usize
 }
 
 impl Resolver {
     pub fn new() -> Resolver {
-        Resolver {
-            env: Env::new()
-        }
+        let mut res = Resolver {
+            list: vec![],
+            cur: 0
+        };
+        let pos = 0;
+        res.list.push(ResolverNode {
+            env: Env::new(),
+            is_function: false,
+            pos
+        });
+        res
     }
 
-    fn access(&mut self, name: &Token) -> Result<u32, &'static str> {
+    fn parent(&mut self) -> bool {
+        if self.cur == 0 {return false}
+        self.cur -= 1;
+        true
+    }
+
+    fn child(&mut self) -> bool {
+        self.cur += 1;
+        self.cur < self.list.len()
+    }
+
+    fn new_child(&mut self) {
+        self.cur += 1;
+        let pos = self.list.len() - 1;
+        self.list.push(ResolverNode {
+            env: Env::new(),
+            is_function: true,
+            pos
+        });
+    }
+
+    fn pop(&mut self) {
+        self.cur -= 1;
+        self.list.pop();
+    }
+
+    fn this_node(&mut self) -> &mut ResolverNode {
+        self.list.get_mut(self.cur).expect("This is a problem with the resolver itself")
+    }
+} 
+
+pub struct ResolverNode {
+    env: Env,
+    is_function: bool,
+    pos: usize
+}
+
+impl Resolver {
+    fn local(&mut self, name: &Token) -> Result<u16, &'static str> {
         let mut id = -1;
-        for i in (0..self.env.locals.len()).rev() {
-            let local = self.env.get(i);
+        for i in (0..self.this_node().env.locals.len()).rev() {
+            let local = self.this_node().env.get(i);
             if local.name.val == name.val{
                 id = i as i32;
                 break;
@@ -24,11 +85,35 @@ impl Resolver {
             return Err("Usage of an undefined variable");
         }
         else {
-            let mut id: u32 = id as u32;
+            let id = if self.this_node().is_function {id as u16 + 1} else {id as u16};
             return Ok(id)
         }
     }
 
+    fn upvalue(&mut self, name: &Token) -> Result<u16, &'static str> {
+        if self.parent() {
+            let id = self.local(name)?;
+            let id = if self.this_node().is_function {id + 1} else {id};
+            let upv_id = self.this_node().env.add_upvalue(UpValue {
+                is_local: true,
+                id
+            });
+            self.child();
+            return Ok(upv_id)
+        }
+        Err("Usage of an undefined variable")
+    }
+
+    fn access(&mut self, name: &Token) -> Result<ResolveType, &'static str> {
+        if let Ok(id) = self.local(name) {
+            return Ok(ResolveType::Local {id});
+        }
+        let id = self.upvalue(name)?;
+        return Ok(ResolveType::UpValue {id});
+    }
+}
+
+impl Resolver {
     pub fn resolve(&mut self, program: Program) -> Result<Program, &'static str> {
         self.resolve_stmts(program)
     }
@@ -45,33 +130,43 @@ impl Resolver {
         match stmt {
             Stmt::MutDecl(name, val) => {
                 let val = self.resolve_expr(*val)?;
-                if self.env.is_redefined(&name) {
+                if self.this_node().env.is_redefined(&name) {
                     return Err("Tried to redeclare a variable in the same scope");
                 }
-                self.env.add(name.clone());
-                let id = self.env.locals.len() as u16 - 1;
+                self.this_node().env.add_local(name.clone());
+                let id = self.this_node().env.locals.len() as u16 - 1;
                 Ok(Stmt::ResolvedMutDecl(id, Box::new(val)))
             },
             Stmt::Expr(expr) => {
                 Ok(Stmt::Expr(Box::new(self.resolve_expr(*expr)?)))
             },
             Stmt::FnDecl(name, params, body) => {
-                if self.env.is_redefined(&name) {
+                if self.this_node().env.is_redefined(&name) {
+                    println!("{}", name);
                     return Err("Tried to redeclare a variable in the same scope");
                 }
-                self.env.add(name.clone());
+                self.this_node().env.add_local(name.clone());
 
-                self.env.open();
+                let id = self.this_node().env.locals.len() as u16 - 1;
+
+                self.new_child();
 
                 for param in params.clone() {
-                    self.env.add(param);
+                    self.this_node().env.add_local(param);
                 }
                 
                 let body = self.resolve_expr(*body)?;
+                let upvalues = self.this_node().env.upvalues.clone();
 
-                self.env.close();
-                let id = self.env.locals.len() as u16 - 1;
-                Ok(Stmt::ResolvedFnDecl(name, id, params, Box::new(body)))
+                self.pop();
+                
+                Ok(Stmt::ResolvedFnDecl {
+                    name,
+                    id,
+                    params,
+                    upvalues,
+                    body: Box::new(body)
+                })
             },
             _ => panic!()
         }
@@ -84,6 +179,7 @@ impl Resolver {
                     let right = self.resolve_expr(*right)?;
                     if let Expr::Access(l) = *(left.clone()) {
                         let id = self.access(&l)?;
+                        println!("{}", id);
                         return Ok(Expr::ResolvedAssign(l, id, Box::new(right)));
                     }
                     else {
@@ -101,9 +197,9 @@ impl Resolver {
                 Ok(Expr::ResolvedAccess(name, id))
             },
             Expr::Block(stmts) => {
-                self.env.open();
+                self.this_node().env.open();
                 let mut stmts = self.resolve_stmts(stmts)?;
-                let pop_count = self.env.close();
+                let pop_count = self.this_node().env.close();
                 Ok(Expr::ResolvedBlock(stmts, pop_count))
             },
             Expr::Unary(op, right) => {

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -13,10 +13,11 @@ impl Resolver {
 
     fn access(&mut self, name: &Token) -> Result<u32, &'static str> {
         let mut id = -1;
-        for i in (0..self.env.locals.len()) {
+        for i in (0..self.env.locals.len()).rev() {
             let local = self.env.get(i);
             if local.name.val == name.val{
                 id = i as i32;
+                break;
             }
         }
         if id < 0 {

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -92,7 +92,7 @@ impl Resolver {
             if let Ok(id) = self.local(name) {
                 self.frame().env.capture(id);
                 self.child();
-                let upv_id = self.frame().env.add_upvalue(UpValue {
+                let upv_id = self.frame().env.add_upvalue(UpValueIndex {
                     is_local: true,
                     id
                 });
@@ -101,7 +101,7 @@ impl Resolver {
             else {
                 let id = self.upvalue(name)?;
                 self.child();
-                let upv_id = self.frame().env.add_upvalue(UpValue {
+                let upv_id = self.frame().env.add_upvalue(UpValueIndex {
                     is_local: false,
                     id
                 });

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -53,13 +53,23 @@ impl Resolver {
             Stmt::Expr(expr) => {
                 Ok(Stmt::Expr(Box::new(self.resolve_expr(*expr)?)))
             },
-            Stmt::FnDecl(name, body) => {
+            Stmt::FnDecl(name, params, body) => {
                 if self.env.is_redefined(&name) {
                     return Err("Tried to redeclare a variable in the same scope");
                 }
                 self.env.add(name.clone());
+
+                self.env.open();
+
+                for param in params.clone() {
+                    self.env.add(param);
+                }
+                
                 let body = self.resolve_expr(*body)?;
-                Ok(Stmt::FnDecl(name, Box::new(body)))
+
+                self.env.close();
+
+                Ok(Stmt::FnDecl(name, params, Box::new(body)))
             },
             _ => panic!()
         }

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -206,8 +206,8 @@ impl Resolver {
             Expr::Block(stmts) => {
                 self.frame().env.open();
                 let mut stmts = self.resolve_stmts(stmts)?;
-                let pop_count = self.frame().env.close();
-                Ok(Expr::ResolvedBlock(stmts, pop_count))
+                self.frame().env.close();
+                Ok(Expr::ResolvedBlock(stmts))
             },
             Expr::Unary(op, right) => {
                 let right = self.resolve_expr(*right)?;

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -48,7 +48,7 @@ impl Resolver {
         self.cur += 1;
         let pos = self.list.len() - 1;
         self.list.push(ResolverNode {
-            env: Env::new_function(),
+            env: Env::new(),
             pos
         });
     }
@@ -82,7 +82,7 @@ impl Resolver {
             return Err("Usage of an undefined variable");
         }
         else {
-            let id = self.frame().env.add_func_offset(id as u16);
+            let id = id as u16;
             return Ok(id)
         }
     }
@@ -132,7 +132,7 @@ impl Resolver {
                 self.frame().env.add_local(name.clone());
                 
                 let id = self.frame().env.locals.len() as u16 - 1;
-                let id = self.frame().env.add_func_offset(id);
+                // let id = self.frame().env.add_func_offset(id);
 
                 Ok(Stmt::ResolvedMutDecl(id, Box::new(val)))
             },
@@ -147,9 +147,11 @@ impl Resolver {
                 self.frame().env.add_local(name.clone());
 
                 let id = self.frame().env.locals.len() as u16 - 1;
-                let id = self.frame().env.add_func_offset(id);
+                // let id = self.frame().env.add_func_offset(id);
 
                 self.new_child();
+
+                self.frame().env.add_local(name.clone());
 
                 for param in params.clone() {
                     self.frame().env.add_local(param);

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -89,13 +89,23 @@ impl Resolver {
 
     fn upvalue(&mut self, name: &Token) -> Result<u16, &'static str> {
         if self.parent() {
-            let id = self.local(name)?;
-            let upv_id = self.frame().env.add_upvalue(UpValue {
-                is_local: true,
-                id
-            });
-            self.child();
-            return Ok(upv_id)
+            if let Ok(id) = self.local(name) {
+                self.child();
+                let upv_id = self.frame().env.add_upvalue(UpValue {
+                    is_local: true,
+                    id
+                });
+                return Ok(upv_id)
+            }
+            else {
+                let id = self.upvalue(name)?;
+                self.child();
+                let upv_id = self.frame().env.add_upvalue(UpValue {
+                    is_local: true,
+                    id
+                });
+                return Ok(upv_id)
+            }
         }
         Err("Usage of an undefined variable")
     }

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -117,6 +117,15 @@ impl Resolver {
                 }
                 Ok(Expr::IfElse(Box::new(cond), Box::new(ib), eb))
             },
+            Expr::FnCall(name, args, pop_count) => {
+                let name = self.resolve_expr(*name)?;
+                let mut rargs = Vec::<Expr>::new();
+                for arg in args {
+                    rargs.push(self.resolve_expr(arg)?)
+                }
+
+                Ok(Expr::FnCall(Box::new(name), rargs, pop_count))
+            }
             _ => Ok(expr)
         }
     }

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -54,11 +54,11 @@ impl Resolver {
                 Ok(Stmt::Expr(Box::new(self.resolve_expr(*expr)?)))
             },
             Stmt::FnDecl(name, body) => {
-                let body = self.resolve_expr(*body)?;
                 if self.env.is_redefined(&name) {
                     return Err("Tried to redeclare a variable in the same scope");
                 }
                 self.env.add(name.clone());
+                let body = self.resolve_expr(*body)?;
                 Ok(Stmt::FnDecl(name, Box::new(body)))
             },
             _ => panic!()

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -48,7 +48,8 @@ impl Resolver {
                     return Err("Tried to redeclare a variable in the same scope");
                 }
                 self.env.add(name.clone());
-                Ok(Stmt::MutDecl(name, Box::new(val)))
+                let id = self.env.locals.len() as u16 - 1;
+                Ok(Stmt::ResolvedMutDecl(id, Box::new(val)))
             },
             Stmt::Expr(expr) => {
                 Ok(Stmt::Expr(Box::new(self.resolve_expr(*expr)?)))
@@ -68,8 +69,8 @@ impl Resolver {
                 let body = self.resolve_expr(*body)?;
 
                 self.env.close();
-
-                Ok(Stmt::FnDecl(name, params, Box::new(body)))
+                let id = self.env.locals.len() as u16 - 1;
+                Ok(Stmt::ResolvedFnDecl(name, id, params, Box::new(body)))
             },
             _ => panic!()
         }

--- a/src/upvalue.rs
+++ b/src/upvalue.rs
@@ -1,0 +1,16 @@
+use crate::*;
+
+#[derive(Clone, PartialEq, Debug)]
+pub struct UpValue {
+    pub loc: *mut Value,
+    // next: *const UpValue
+}
+
+impl UpValue {
+    pub fn from_ref(val: &mut Value) -> UpValue {
+        UpValue {
+            loc: val as *mut Value,
+            // next: std::ptr::null()
+        }
+    } 
+}

--- a/src/upvalue.rs
+++ b/src/upvalue.rs
@@ -1,16 +1,36 @@
 use crate::*;
 
 #[derive(Clone, PartialEq, Debug)]
+pub enum UpValueLocation {
+    Stack(u16),
+    Heap(*mut Value)
+}
+
+#[derive(Clone, PartialEq)]
 pub struct UpValue {
-    pub loc: *mut Value,
-    // next: *const UpValue
+    pub loc: UpValueLocation
 }
 
 impl UpValue {
-    pub fn from_ref(val: &mut Value) -> UpValue {
+    pub fn stack(id: u16) -> UpValue {
         UpValue {
-            loc: val as *mut Value,
-            // next: std::ptr::null()
+            loc: UpValueLocation::Stack(id)
         }
-    } 
+    }
+
+    pub fn close(&mut self, at: *mut Value ) {
+        self.loc = UpValueLocation::Heap(at);
+    }
+}
+
+impl std::fmt::Debug for UpValue {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self.loc);
+        if let UpValueLocation::Heap(ptr) = self.loc {
+            unsafe {
+                write!(f, " val {}", *ptr);
+            }
+        }
+        Ok(())
+    }
 }

--- a/src/value.rs
+++ b/src/value.rs
@@ -5,7 +5,7 @@ pub enum Value {
     Bool(bool),
     Number(f64),
     String(String),
-    Function(Box<Function>),
+    Function(Rc<Function>),
     Null
 }
 

--- a/src/value.rs
+++ b/src/value.rs
@@ -5,7 +5,7 @@ pub enum Value {
     Bool(bool),
     Number(f64),
     String(String),
-    Function(Box<Fn>),
+    Function(Box<Function>),
     Null
 }
 
@@ -15,6 +15,7 @@ impl Value {
             Value::Bool(b) => *b,
             Value::Number(n) => *n!=0.,
             Value::String(s) => s.len() > 0,
+            Value::Function(_) => true,
             Value::Null => false
         }
     }
@@ -26,6 +27,7 @@ impl Value {
                 Ok(num) => return Ok(num),
                 _ => return Err("Could not convert the string to a number")
             },
+            Value::Function(_) => Err("Can't convert a function to a number"),
             Value::Null => return Ok(0.),
             _ => return Err("This operand cannot be converted to a number")
         }
@@ -35,6 +37,7 @@ impl Value {
             Value::String(s) => return Ok(s.clone()),
             Value::Bool(b) => return Ok((if *b {"true"} else {"false"}).to_string()),
             Value::Number(num) => return Ok(num.to_string()),
+            Value::Function(_) => Err("Can't convert a function to a string"),
             Value::Null => return Ok("null".to_string()),
             _ => return Err("This operand cannot be converted to a string")
         }

--- a/src/value.rs
+++ b/src/value.rs
@@ -1,6 +1,6 @@
 use crate::*;
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(PartialEq, Clone)]
 pub enum Value {
     Bool(bool),
     Number(f64),
@@ -72,6 +72,19 @@ impl From<&Token> for Value {
             TokenType::False  => Value::Bool(false),
             TokenType::Null   => Value::Null,
             _ => unimplemented!()
+        }
+    }
+}
+
+impl std::fmt::Debug for Value {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Value::String(s) => write!(f, "{}", s.clone()),
+            Value::Bool(b) => write!(f, "{}", (if *b {"true"} else {"false"}).to_string()),
+            Value::Number(num) => write!(f, "{}", num.to_string()),
+            Value::Function(func) => write!(f, "func {}", func.name),
+            Value::Null => write!(f, "null"),
+            _ => panic!()
         }
     }
 }

--- a/src/value.rs
+++ b/src/value.rs
@@ -5,7 +5,8 @@ pub enum Value {
     Bool(bool),
     Number(f64),
     String(String),
-    Function(Rc<Function>),
+    Function(Box<Function>),
+    Closure(Closure),
     Null,
     Uninitialized
 }
@@ -17,6 +18,7 @@ impl Value {
             Value::Number(n) => *n!=0.,
             Value::String(s) => s.len() > 0,
             Value::Function(_) => true,
+            Value::Closure(_) => true,
             Value::Null => false,
             Value::Uninitialized => panic!()
         }

--- a/src/value.rs
+++ b/src/value.rs
@@ -7,20 +7,27 @@ pub enum Value {
     String(String),
     Function(Rc<Function>),
     Closure(Closure),
+    Captured(*mut Value),
     Null,
     Uninitialized
 }
 
 impl Value {
+    pub fn new_captured(slot: &mut Value) -> Value {
+        Value::Captured(slot as *mut Value)
+    }
+
     pub fn is_truthy(&self) -> bool {
         match self {
             Value::Bool(b) => *b,
             Value::Number(n) => *n!=0.,
             Value::String(s) => s.len() > 0,
-            Value::Function(_) => true,
             Value::Closure(_) => true,
             Value::Null => false,
-            Value::Uninitialized => panic!()
+            
+            Value::Uninitialized | 
+            Value::Function(_) |
+            Value::Captured(_) => panic!()
         }
     }
     pub fn to_number(&self) -> Result<f64, &'static str> {

--- a/src/value.rs
+++ b/src/value.rs
@@ -6,7 +6,8 @@ pub enum Value {
     Number(f64),
     String(String),
     Function(Rc<Function>),
-    Null
+    Null,
+    Uninitialized
 }
 
 impl Value {
@@ -16,7 +17,8 @@ impl Value {
             Value::Number(n) => *n!=0.,
             Value::String(s) => s.len() > 0,
             Value::Function(_) => true,
-            Value::Null => false
+            Value::Null => false,
+            Value::Uninitialized => panic!()
         }
     }
     pub fn to_number(&self) -> Result<f64, &'static str> {
@@ -84,6 +86,7 @@ impl std::fmt::Debug for Value {
             Value::Number(num) => write!(f, "{}", num.to_string()),
             Value::Function(func) => write!(f, "func {}", func.name),
             Value::Null => write!(f, "null"),
+            Value::Uninitialized => write!(f, "-"),
             _ => panic!()
         }
     }

--- a/src/value.rs
+++ b/src/value.rs
@@ -1,22 +1,17 @@
 use crate::*;
 
-#[derive(PartialEq, Clone)]
+#[derive(PartialEq, Clone, Debug)]
 pub enum Value {
     Bool(bool),
     Number(f64),
     String(String),
     Function(Rc<Function>),
     Closure(Closure),
-    Captured(*mut Value),
     Null,
     Uninitialized
 }
 
 impl Value {
-    pub fn new_captured(slot: &mut Value) -> Value {
-        Value::Captured(slot as *mut Value)
-    }
-
     pub fn is_truthy(&self) -> bool {
         match self {
             Value::Bool(b) => *b,
@@ -26,8 +21,7 @@ impl Value {
             Value::Null => false,
             
             Value::Uninitialized | 
-            Value::Function(_) |
-            Value::Captured(_) => panic!()
+            Value::Function(_) => panic!()
         }
     }
     pub fn to_number(&self) -> Result<f64, &'static str> {
@@ -87,14 +81,14 @@ impl From<&Token> for Value {
     }
 }
 
-impl std::fmt::Debug for Value {
+impl std::fmt::Display for Value {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
             Value::String(s) => write!(f, "{}", s.clone()),
             Value::Bool(b) => write!(f, "{}", (if *b {"true"} else {"false"}).to_string()),
             Value::Number(num) => write!(f, "{}", num.to_string()),
             Value::Function(func) => write!(f, "func {}", func.name),
-            Value::Closure(clsr) => write!(f, "func {}", clsr.func.name),
+            Value::Closure(clsr) => write!(f, "clsr {}", clsr.func.name),
             Value::Null => write!(f, "null"),
             Value::Uninitialized => write!(f, "-"),
             _ => panic!()

--- a/src/value.rs
+++ b/src/value.rs
@@ -5,6 +5,7 @@ pub enum Value {
     Bool(bool),
     Number(f64),
     String(String),
+    Function(Box<Fn>),
     Null
 }
 

--- a/src/value.rs
+++ b/src/value.rs
@@ -5,7 +5,7 @@ pub enum Value {
     Bool(bool),
     Number(f64),
     String(String),
-    Function(Box<Function>),
+    Function(Rc<Function>),
     Closure(Closure),
     Null,
     Uninitialized
@@ -87,6 +87,7 @@ impl std::fmt::Debug for Value {
             Value::Bool(b) => write!(f, "{}", (if *b {"true"} else {"false"}).to_string()),
             Value::Number(num) => write!(f, "{}", num.to_string()),
             Value::Function(func) => write!(f, "func {}", func.name),
+            Value::Closure(clsr) => write!(f, "func {}", clsr.func.name),
             Value::Null => write!(f, "null"),
             Value::Uninitialized => write!(f, "-"),
             _ => panic!()

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -9,8 +9,7 @@ pub struct VM {
 
     stack: Stack,
 
-    debug: bool,
-    pub time: Duration
+    debug: bool
 }
 
 impl VM {
@@ -19,8 +18,7 @@ impl VM {
             frame: CallFrame::new(chk, 0),
             callstack: Vec::<CallFrame>::new(),
             stack: Stack::new(),
-            debug,
-            time: Duration::new(0,0)
+            debug
         }
     }
         
@@ -78,19 +76,11 @@ impl VM {
             if let Some(next) = self.next_instr() {
                 match next {
                     Instruction::Return => {
-                        
-                        use std::time::{Instant};
-                        let now = Instant::now();
-
                         if let Some(frame) = self.callstack.pop() {
                             let val = self.pop_stack();
                             self.stack.truncate(self.frame.stack_base);
                             self.frame = frame;
                             self.stack.push(val);
-
-                            let new_now = Instant::now();
-                            let time = new_now - now;
-                            self.time += time;
                         }
                         else {
 
@@ -243,16 +233,9 @@ impl VM {
                         self.pop_stack();
                     },
                     Instruction::PushVariable(id) => {
-                        use std::time::{Instant};
-                        let now = Instant::now();
-
                         let id = *id + self.frame.stack_base as u16;
                         let var = self.get_stack(id).clone();
                         self.stack.push(var);
-
-                        let new_now = Instant::now();
-                        let time = (new_now - now).as_millis();
-                        // self.time += time as f64 / 1000.;
                     },
                     Instruction::Assign(id) => {
                         let id = *id;
@@ -293,14 +276,11 @@ impl VM {
                         self.stack.push(hangon);
                     },
                     Instruction::FnCall(arg_count) => {
-                        use std::time::{Instant};
-                        let now = Instant::now();
                         let arg_count = arg_count.clone();
                         let funcpos = self.stack.len() as u16 - 1 - arg_count;
                         let func = self.get_stack(funcpos);
                         if let Value::Function(func) = func {
                             let mut new_frame = CallFrame::from_function(Rc::clone(func), funcpos as usize);
-                            let test = new_frame.clone();
 
                             let parent_frame = std::mem::replace(&mut self.frame, new_frame);
 
@@ -309,8 +289,7 @@ impl VM {
                         else {
                             return Err("Tried to call a value which isn't a function");
                         }
-                        let new_now = Instant::now();
-                        // self.time += new_now - now;
+                        
                     },
 
                     #[allow(unreachable_patterns)]

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -238,12 +238,12 @@ impl VM {
                         self.stack.push(var);
                     },
                     Instruction::Assign(id) => {
-                        let id = *id;
+                        let id = *id + self.frame.stack_base as u16;
                         let val = self.get_stack_top().clone();
                         self.set_stack(id, val);
                     },
                     Instruction::DeclareAssign(id) => {
-                        let id = *id;
+                        let id = *id + self.frame.stack_base as u16;
                         let val = self.pop_stack();
                         self.set_stack(id, val);
                     },

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -23,7 +23,7 @@ impl VM {
         
     fn next_instr(&mut self) -> Option<&Instruction> {
         self.frame.cur_instr += 1;
-        self.frame.chk.try_get_instr(self.frame.cur_instr - 1)
+        self.frame.func.chk.try_get_instr(self.frame.cur_instr - 1)
     }
 
     fn pop_stack(&mut self) -> Value {
@@ -68,7 +68,7 @@ impl VM {
 
             if self.debug {
                 self.print_stack();
-                self.frame.chk.print_instr(self.frame.cur_instr, false);
+                self.frame.func.chk.print_instr(self.frame.cur_instr, false);
 
                 println!();
             }
@@ -85,7 +85,7 @@ impl VM {
                     },
                     Instruction::PushConstant(id) => {
                         let id = *id;
-                        let constant: &Value = self.frame.chk.get_const(id);
+                        let constant: &Value = self.frame.func.chk.get_const(id);
                         self.stack.push(constant.clone());
                     },
                     Instruction::PushTrue => {
@@ -217,7 +217,7 @@ impl VM {
 
                         let val = a.to_string().unwrap_or("".to_string());
                         //add filename
-                        let line_no = self.frame.chk.get_line_no(self.frame.cur_instr as u32);
+                        let line_no = self.frame.func.chk.get_line_no(self.frame.cur_instr as u32);
                         println!("[{}] {}", line_no, val);
                         //maybe don't pop at all?
 

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -295,9 +295,9 @@ mod tests {
         chk.add_instr(Instruction::Negate, 0);
         chk.add_instr(Instruction::Return, 0);
 
-        let mut vm = VM::new(true);
+        let mut vm = VM::new(chk, true);
 
-        assert_eq!(vm.execute(chk), Ok(()));
+        assert_eq!(vm.execute(), Ok(()));
     }
 
     #[test]
@@ -340,9 +340,9 @@ mod tests {
 
         chk.add_instr(Instruction::Return, 0);
 
-        let mut vm = VM::new(true);
+        let mut vm = VM::new(chk, true);
 
-        assert_eq!(vm.execute(chk), Ok(()));
+        assert_eq!(vm.execute(), Ok(()));
     }
 
     #[test]
@@ -357,8 +357,8 @@ mod tests {
 
         chk.add_instr(Instruction::Return, 0);
 
-        let mut vm = VM::new(true);
+        let mut vm = VM::new(chk, true);
 
-        assert_eq!(vm.execute(chk), Ok(()));
+        assert_eq!(vm.execute(), Ok(()));
     }
 }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -63,7 +63,7 @@ impl VM {
             self.get_stack_mut(self.frame.stack_base as u16 + upvalue.id) as *mut Value
         }
         else {
-            panic!()
+            self.frame.clsr.captured.get_mut(upvalue.id as usize).expect("").clone()
         }
     }
 
@@ -253,8 +253,7 @@ impl VM {
                         unsafe {
                             let id = *id;
                             let value = self.frame.clsr.captured.get(id as usize).expect("");
-                            let value = value.clone();
-                            let value = (*value).clone();
+                            let value = (**value).clone();
                             self.stack.push(value);
                         }
                     },
@@ -262,6 +261,14 @@ impl VM {
                         let id = *id + self.frame.stack_base as u16;
                         let val = self.get_stack_top().clone();
                         self.set_stack(id, val);
+                    },
+                    Instruction::SetCaptured(id) => {
+                        unsafe {
+                            let id = *id;
+                            let value = self.frame.clsr.captured.get(id as usize).expect("");
+                            let set_to = self.get_stack_top().clone();
+                            **value = set_to;
+                        }
                     },
                     Instruction::Declare(id) => {
                         let id = *id + self.frame.stack_base as u16;

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -8,7 +8,6 @@ pub struct VM {
     callstack: Vec<CallFrame>,
 
     stack: Stack,
-
     debug: bool
 }
 
@@ -294,7 +293,6 @@ impl VM {
                         else {
                             return Err("Tried to call a value which isn't a function");
                         }
-                        
                     },
                     Instruction::Reserve(reserve_count) => {
                         let reserve_count = *reserve_count;

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -255,6 +255,14 @@ impl VM {
                     Instruction::Jump(jump_count) => {
                         let jump_count = *jump_count as usize;
                         self.cur_instr += jump_count;
+                    },
+                    Instruction::EndBlock(pop_count) => {
+                        let pop_count = pop_count.clone();
+                        let hangon = self.pop_stack();
+                        for _ in 0..pop_count {
+                            self.pop_stack();
+                        }
+                        self.stack.push(hangon);
                     }
 
                     #[allow(unreachable_patterns)]

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -299,8 +299,10 @@ impl VM {
                         self.stack.resize(self.stack.len() + reserve_count as usize, Value::Uninitialized);
                     },
                     Instruction::Closure(id, const_id) => {
-                        let id = *id;
-                        let closure = match self.frame.clsr.func.chk.get_const(id).clone() {
+                        let const_id = *const_id;
+                        let id = *id + self.frame.stack_base as u16;
+                        
+                        let closure = match self.frame.clsr.func.chk.get_const(const_id).clone() {
                             Value::Function(func) => Closure::from_function(func),
                             _ => panic!("This is a problem with the Vm itself")
                         };

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -242,6 +242,16 @@ impl VM {
                         let val = self.get_stack_top().clone();
                         self.set_stack(id, val);
                     },
+                    Instruction::DeclareAssign(id) => {
+                        let id = *id;
+                        let val = self.pop_stack();
+                        self.set_stack(id, val);
+                    },
+                    Instruction::DeclareAssignConstant(id, const_id) => {
+                        let id = *id;
+                        let val = self.frame.func.chk.get_const(id).clone();
+                        self.set_stack(id, val);
+                    },
                     Instruction::JumpIfFalsy(jump_count) => {
                         let jump_count = *jump_count as usize;
                         let val = self.get_stack_top();
@@ -267,14 +277,6 @@ impl VM {
                         let jump_count = *jump_count as usize;
                         self.frame.cur_instr += jump_count;
                     },
-                    Instruction::EndBlock(pop_count) => {
-                        let pop_count = pop_count.clone();
-                        let hangon = self.pop_stack();
-                        for _ in 0..pop_count {
-                            self.pop_stack();
-                        }
-                        self.stack.push(hangon);
-                    },
                     Instruction::FnCall(arg_count) => {
                         let arg_count = arg_count.clone();
                         let funcpos = self.stack.len() as u16 - 1 - arg_count;
@@ -290,6 +292,10 @@ impl VM {
                             return Err("Tried to call a value which isn't a function");
                         }
                         
+                    },
+                    Instruction::Reserve(reserve_count) => {
+                        let reserve_count = *reserve_count;
+                        self.stack.resize(self.stack.len() + reserve_count as usize, Value::Uninitialized);
                     },
 
                     #[allow(unreachable_patterns)]

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -79,7 +79,7 @@ impl VM {
     fn close_upvalues(&mut self) {
         let captured = self.frame.clsr.func.captured.clone();
 
-        for (id, i) in captured.iter().zip(0..captured.len()) {
+        for id in captured.iter() {
             let slot = self.frame.stack_base as u16 + id;
 
             let cur_value = self.get_stack_mut(slot);


### PR DESCRIPTION
This branch introduces functions and closures.
Functions are first class, can be passed as arguments and returned from functions.
Closures store `UpValueLocation`s to either a stack slot or a place in the memory (a pointer).
The location is changed when the enclosing function returns.
Under the hood, all functions become closures in the VM.

The resolver now counts all the variables that will be used in the frame and the VM reserves that many slots at the beginning of the frame. (The resolver does not remove locals in the `close()` method anymore). This fixes #22.

As a side note, the null value is now correctly the `null` keyword instead of `~`, which will become the discard operator (#9).